### PR TITLE
Corrige saída e entrada de dados de resultados de operações

### DIFF
--- a/src/CALCULADORA.asm
+++ b/src/CALCULADORA.asm
@@ -10,7 +10,7 @@ extern EXPONENCIACAO
 extern MOD
 
 global precision
-global print_output
+global write_output
 global read_input
 
 section .data
@@ -49,7 +49,7 @@ exit:               ; Encerra programa
     mov ebx, 0
     int 80h
 
-print_output:
+write_output:
     ; Imprime uma string que foi passada pela pilha por parâmetro, com seu tamanho empilhado em seguida
     enter 0,0
     
@@ -79,7 +79,7 @@ print_welcome:
     push DWORD bem_vindo
     push DWORD bem_vindo_len
 
-    call print_output
+    call write_output
 
     leave
     ret
@@ -104,7 +104,7 @@ print_hola:
     push DWORD hola
     push DWORD hola_len
 
-    call print_output
+    call write_output
 
     leave
     ret
@@ -114,7 +114,7 @@ print_name:
     push DWORD user_name
     push DWORD user_name_len
 
-    call print_output
+    call write_output
 
     leave
     ret
@@ -124,7 +124,7 @@ print_welcome2:
     push DWORD bem_vindo2
     push DWORD bem_vindo2_len
 
-    call print_output
+    call write_output
 
     leave
     ret
@@ -134,7 +134,7 @@ print_precision_question:
     push DWORD precision_question
     push DWORD precision_question_len
 
-    call print_output
+    call write_output
 
     leave
     ret
@@ -154,7 +154,7 @@ print_menu:
     push DWORD menu
     push DWORD menu_len
 
-    call print_output
+    call write_output
 
     leave
     ret
@@ -200,7 +200,7 @@ case_soma:
     call find_length 
     push DWORD eax
 
-    call print_output
+    call write_output
 
     jmp wait_for_enter
 
@@ -211,7 +211,7 @@ case_subtracao:
     call find_length 
     push DWORD eax
 
-    call print_output
+    call write_output
 
     jmp wait_for_enter
 
@@ -222,7 +222,7 @@ case_multiplicacao:
     call find_length 
     push DWORD eax
 
-    call print_output
+    call write_output
 
     jmp wait_for_enter
 
@@ -233,7 +233,7 @@ case_divisao:
     call find_length 
     push DWORD eax
 
-    call print_output
+    call write_output
 
     jmp wait_for_enter
 
@@ -243,7 +243,7 @@ case_exponenciacao:
     call find_length 
     push DWORD eax
 
-    call print_output
+    call write_output
 
     jmp wait_for_enter
 
@@ -253,7 +253,7 @@ case_mod:
     call find_length 
     push DWORD eax
 
-    call print_output
+    call write_output
 
     jmp wait_for_enter
 

--- a/src/CALCULADORA.asm
+++ b/src/CALCULADORA.asm
@@ -10,6 +10,8 @@ extern EXPONENCIACAO
 extern MOD
 
 global precision
+global print_output
+global read_input
 
 section .data
 bem_vindo       db 'Bem-vindo. Digite seu nome: '
@@ -47,7 +49,7 @@ exit:               ; Encerra programa
     mov ebx, 0
     int 80h
 
-print_msg:
+print_output:
     ; Imprime uma string que foi passada pela pilha por parâmetro, com seu tamanho empilhado em seguida
     enter 0,0
     
@@ -60,7 +62,7 @@ print_msg:
     leave
     ret
 
-read_string:
+read_input:
     enter 0,0
     
     mov eax, 3
@@ -77,7 +79,7 @@ print_welcome:
     push DWORD bem_vindo
     push DWORD bem_vindo_len
 
-    call print_msg
+    call print_output
 
     leave
     ret
@@ -87,7 +89,7 @@ get_name:
     push DWORD user_name
     push DWORD 16
     
-    call read_string
+    call read_input
 
     ; Limpa a quebra de linha
     dec eax
@@ -102,7 +104,7 @@ print_hola:
     push DWORD hola
     push DWORD hola_len
 
-    call print_msg
+    call print_output
 
     leave
     ret
@@ -112,7 +114,7 @@ print_name:
     push DWORD user_name
     push DWORD user_name_len
 
-    call print_msg
+    call print_output
 
     leave
     ret
@@ -122,7 +124,7 @@ print_welcome2:
     push DWORD bem_vindo2
     push DWORD bem_vindo2_len
 
-    call print_msg
+    call print_output
 
     leave
     ret
@@ -132,7 +134,7 @@ print_precision_question:
     push DWORD precision_question
     push DWORD precision_question_len
 
-    call print_msg
+    call print_output
 
     leave
     ret
@@ -142,7 +144,7 @@ get_precison:
     push DWORD precision
     push DWORD 2
     
-    call read_string
+    call read_input
 
     leave
     ret
@@ -152,7 +154,7 @@ print_menu:
     push DWORD menu
     push DWORD menu_len
 
-    call print_msg
+    call print_output
 
     leave
     ret
@@ -162,7 +164,7 @@ get_option:
     push DWORD op_option
     push DWORD 2
     
-    call read_string
+    call read_input
 
     leave
     ret
@@ -198,7 +200,7 @@ case_soma:
     call find_length 
     push DWORD eax
 
-    call print_msg
+    call print_output
 
     jmp wait_for_enter
 
@@ -209,7 +211,7 @@ case_subtracao:
     call find_length 
     push DWORD eax
 
-    call print_msg
+    call print_output
 
     jmp wait_for_enter
 
@@ -220,7 +222,7 @@ case_multiplicacao:
     call find_length 
     push DWORD eax
 
-    call print_msg
+    call print_output
 
     jmp wait_for_enter
 
@@ -231,7 +233,7 @@ case_divisao:
     call find_length 
     push DWORD eax
 
-    call print_msg
+    call print_output
 
     jmp wait_for_enter
 
@@ -241,7 +243,7 @@ case_exponenciacao:
     call find_length 
     push DWORD eax
 
-    call print_msg
+    call print_output
 
     jmp wait_for_enter
 
@@ -251,13 +253,13 @@ case_mod:
     call find_length 
     push DWORD eax
 
-    call print_msg
+    call print_output
 
     jmp wait_for_enter
 
 wait_for_enter:
     push DWORD eax
     push DWORD 1
-    call read_string
+    call read_input
 
     jmp handle_menu

--- a/src/EXPONENCIACAO.asm
+++ b/src/EXPONENCIACAO.asm
@@ -3,7 +3,7 @@ global EXPONENCIACAO
 extern read_int
 extern read_int_16
 extern int_to_string
-extern print_output
+extern write_output
 
 extern precision
 
@@ -94,7 +94,7 @@ section .text
 
         push DWORD msg_overflow
         push DWORD size_msg_overflow
-        call print_output
+        call write_output
 
         leave
         ret

--- a/src/EXPONENCIACAO.asm
+++ b/src/EXPONENCIACAO.asm
@@ -3,6 +3,7 @@ global EXPONENCIACAO
 extern read_int
 extern read_int_16
 extern int_to_string
+extern print_output
 
 extern precision
 
@@ -77,11 +78,7 @@ section .text
             jmp final_exponenciacao
 
         overflow_handler: 
-            mov eax, 4
-            mov ebx, 1
-            mov ecx, msg_overflow
-            mov edx, size_msg_overflow
-            int 80h
+            call print_overflow
 
             mov eax, 1
             mov ebx, 0
@@ -89,5 +86,15 @@ section .text
 
         final_exponenciacao:
             pop ebx
+        leave
+        ret
+
+    print_overflow:
+        enter 0,0
+
+        push DWORD msg_overflow
+        push DWORD size_msg_overflow
+        call print_output
+
         leave
         ret

--- a/src/MULTIPLICACAO.asm
+++ b/src/MULTIPLICACAO.asm
@@ -3,6 +3,7 @@ global MULTIPLICACAO
 extern read_int
 extern read_int_16
 extern int_to_string
+extern print_output
 
 extern precision
 
@@ -55,11 +56,7 @@ section .text
                 jmp final_mul
 
         overflow_handler: 
-            mov eax, 4
-            mov ebx, 1
-            mov ecx, msg_overflow
-            mov edx, size_msg_overflow
-            int 80h
+            call print_overflow
 
             mov eax, 1
             mov ebx, 0
@@ -67,5 +64,15 @@ section .text
 
         final_mul:
             pop ebx
+        leave
+        ret
+
+    print_overflow:
+        enter 0,0
+
+        push DWORD msg_overflow
+        push DWORD size_msg_overflow
+        call print_output
+
         leave
         ret

--- a/src/MULTIPLICACAO.asm
+++ b/src/MULTIPLICACAO.asm
@@ -3,7 +3,7 @@ global MULTIPLICACAO
 extern read_int
 extern read_int_16
 extern int_to_string
-extern print_output
+extern write_output
 
 extern precision
 
@@ -72,7 +72,7 @@ section .text
 
         push DWORD msg_overflow
         push DWORD size_msg_overflow
-        call print_output
+        call write_output
 
         leave
         ret

--- a/src/read_int.asm
+++ b/src/read_int.asm
@@ -1,4 +1,4 @@
-extern print_output
+extern write_output
 extern read_input
 
 global read_int
@@ -103,7 +103,7 @@ section .text
 
         push DWORD msg
         push DWORD SIZE_MSG
-        call print_output
+        call write_output
 
         leave
         ret
@@ -124,7 +124,7 @@ section .text
 
         push DWORD erro
         push DWORD size_erro
-        call print_output
+        call write_output
 
         leave
         ret

--- a/src/read_int.asm
+++ b/src/read_int.asm
@@ -1,3 +1,6 @@
+extern print_output
+extern read_input
+
 global read_int
 
 section .data
@@ -18,19 +21,10 @@ section .bss
 
 section .text
     read_int:
-        ; TODO: remover print da mensagem para digitar precisao 
-        mov eax, 4
-        mov ebx, 1
-        mov ecx, msg
-        mov edx, SIZE_MSG
-        int 80h
-        ; TODO: remover linhas acima ate comentario quando integrar todo o menu
+        
+        call ask_number
 
-        mov eax, 3
-        mov ebx, 0
-        mov ecx, input_buffer
-        mov edx, 15
-        int 80h
+        call read_number
 
         mov esi, input_buffer
         mov edi, result
@@ -79,11 +73,7 @@ section .text
             jmp final
         
         invalid_digit:
-            mov eax, 4
-            mov ebx, 1
-            mov ecx, erro
-            mov edx, size_erro
-            int 80h
+            call print_error
         
         handle_negative:
             mov byte [esp], 1
@@ -106,4 +96,35 @@ section .text
 
             ; eax contem conteudo de retorno
 
+        ret
+
+    ask_number:
+        enter 0,0
+
+        push DWORD msg
+        push DWORD SIZE_MSG
+        call print_output
+
+        leave
+        ret
+
+    read_number:
+        enter 0,0
+
+        push DWORD input_buffer
+        push DWORD 15
+
+        call read_input
+
+        leave
+        ret
+
+    print_error:
+        enter 0,0
+
+        push DWORD erro
+        push DWORD size_erro
+        call print_output
+
+        leave
         ret

--- a/src/read_int_16.asm
+++ b/src/read_int_16.asm
@@ -1,3 +1,6 @@
+extern print_output
+extern read_input
+
 global read_int_16
 
 section .data
@@ -17,19 +20,10 @@ section .bss
 
 section .text
     read_int_16:
-        ; TODO: remover print da mensagem para digitar precisao 
-        mov eax, 4
-        mov ebx, 1
-        mov ecx, msg
-        mov edx, SIZE_MSG
-        int 80h
-        ; TODO: remover linhas acima ate comentario quando integrar todo o menu
 
-        mov eax, 3
-        mov ebx, 0
-        mov ecx, input_buffer
-        mov edx, 15
-        int 80h
+        call ask_number
+
+        call read_number
 
         mov esi, input_buffer
         mov edi, result
@@ -78,11 +72,7 @@ section .text
             jmp final
         
         invalid_digit:
-            mov eax, 4
-            mov ebx, 1
-            mov ecx, erro
-            mov edx, size_erro
-            int 80h
+            call print_error
         
         handle_negative:
             mov byte [esp], 1
@@ -106,4 +96,35 @@ section .text
 
             ; eax contem conteudo de retorno
 
+        ret
+
+    ask_number:
+        enter 0,0
+
+        push DWORD msg
+        push DWORD SIZE_MSG
+        call print_output
+
+        leave
+        ret
+
+    read_number:
+        enter 0,0
+
+        push DWORD input_buffer
+        push DWORD 15
+
+        call read_input
+
+        leave
+        ret
+
+    print_error:
+        enter 0,0
+
+        push DWORD erro
+        push DWORD size_erro
+        call print_output
+
+        leave
         ret

--- a/src/read_int_16.asm
+++ b/src/read_int_16.asm
@@ -1,4 +1,4 @@
-extern print_output
+extern write_output
 extern read_input
 
 global read_int_16
@@ -103,7 +103,7 @@ section .text
 
         push DWORD msg
         push DWORD SIZE_MSG
-        call print_output
+        call write_output
 
         leave
         ret
@@ -124,7 +124,7 @@ section .text
 
         push DWORD erro
         push DWORD size_erro
-        call print_output
+        call write_output
 
         leave
         ret


### PR DESCRIPTION
Todos agora utilizam 'read_input' e 'write_output', definidos na global _start para E/S de dados.